### PR TITLE
NLP-ENGINE-493 export run_analyzer from compiled run.dll on Windows

### DIFF
--- a/include/Api/lite/Arun.h
+++ b/include/Api/lite/Arun.h
@@ -513,6 +513,11 @@ public:
 	static _TCHAR   *assign(int,_TCHAR*,int,long long,Nlppp*,_TCHAR*);
 	static std::_t_ostream *assign(int,_TCHAR*,int,long long,Nlppp*,std::_t_ostream*);	// 11/20/02 AM.
 	static bool		assign(int,_TCHAR*,int,long long,Nlppp*,bool);		// 12/10/02 AM.
+	// `int` rhs disambiguator (NLP-ENGINE-492): codegen emits Arun::attrtype(...)
+	// (returns int) as the rhs of an assign; `int` implicitly converts to bool /
+	// long long / float so the call is ambiguous. This exact-match overload
+	// routes through the long long form.
+	static long long    assign(int,_TCHAR*,int,long long,Nlppp*,int);
 
 	// VARIANTS.
 	static RFASem  *assign(int,_TCHAR*,int,RFASem*,Nlppp*,RFASem*);
@@ -521,6 +526,7 @@ public:
 	static _TCHAR    *assign(int,_TCHAR*,int,RFASem*,Nlppp*,_TCHAR*);
 	static std::_t_ostream *assign(int,_TCHAR*,int,RFASem*,Nlppp*,std::_t_ostream*);//11/20/02 AM.
 	static bool     assign(int,_TCHAR*,int,RFASem*,Nlppp*,bool);	// 12/10/02 AM.
+	static long long     assign(int,_TCHAR*,int,RFASem*,Nlppp*,int);
 
 	// INDEXED ASSIGNMENT.
 	static RFASem *iassign(int,_TCHAR*,int,long long,Nlppp*,RFASem*);
@@ -529,6 +535,7 @@ public:
 	static _TCHAR   *iassign(int,_TCHAR*,int,long long,Nlppp*,_TCHAR*);
 	static std::_t_ostream *iassign(int,_TCHAR*,int,long long,Nlppp*,std::_t_ostream*); // 11/20/02 AM.
 	static bool    iassign(int,_TCHAR*,int,long long,Nlppp*,bool);		// 12/10/02 AM.
+	static long long    iassign(int,_TCHAR*,int,long long,Nlppp*,int);
 
 	static bool truth(long long);
 	static bool truth(float);

--- a/lite/Arun.cpp
+++ b/lite/Arun.cpp
@@ -7487,6 +7487,13 @@ Var::setVal(pair, (val ? 1LL : 0LL));	// No boolean vars yet.
 return val;
 }
 
+// `int` rhs disambiguator (NLP-ENGINE-492). See Arun.h header block.
+long long Arun::assign(
+	int typ, _TCHAR *varname, int nelt, long long index, Nlppp *nlppp, int val)
+{
+return assign(typ, varname, nelt, index, nlppp, (long long)val);
+}
+
 // VARIANTS OF ASSIGN.
 
 RFASem *Arun::assign(														// 05/04/01 AM.
@@ -7605,11 +7612,18 @@ if (!flag)
 return assign(typ,varname,nelt,index,nlppp,val);
 }
 
+// `int` rhs disambiguator (NLP-ENGINE-492). See Arun.h header block.
+long long Arun::assign(
+	int typ, _TCHAR *varname, int nelt, RFASem *index_sem, Nlppp *nlppp, int val)
+{
+return assign(typ, varname, nelt, index_sem, nlppp, (long long)val);
+}
+
 /********************************************
 * FN:		IASSIGN
 * CR:		03/11/02 AM.
 * SUBJ:	INDEXED NLP++ assignment statement, compiled runtime.
-* NOTE:	
+* NOTE:
 ********************************************/
 
 RFASem *Arun::iassign(
@@ -7879,6 +7893,13 @@ arg->setType(IANUM);
 arg->setNum((val ? 1 : 0));
 
 return val;
+}
+
+// `int` rhs disambiguator (NLP-ENGINE-492). See Arun.h header block.
+long long Arun::iassign(
+	int typ, _TCHAR *varname, int nelt, long long index, Nlppp *nlppp, int val)
+{
+return iassign(typ, varname, nelt, index, nlppp, (long long)val);
 }
 
 

--- a/lite/seqn.cpp
+++ b/lite/seqn.cpp
@@ -567,11 +567,24 @@ Arun::set_specialarr_len();												// 06/09/00 AM.
 
 
 // Output prototype.
-*fhead << _T("extern \"C\" bool run_analyzer(Parse *);");
+// __declspec(dllexport) on Windows so GetProcAddress("run_analyzer") can
+// find it inside the compiled run.dll. Without it MSVC builds a DLL with
+// zero exported symbols and the engine's call_runAnalyzer fails silently.
+*fhead << _T("#ifdef _WIN32");
+Gen::nl(fhead);
+*fhead << _T("#define NLP_RUN_EXPORT __declspec(dllexport)");
+Gen::nl(fhead);
+*fhead << _T("#else");
+Gen::nl(fhead);
+*fhead << _T("#define NLP_RUN_EXPORT");
+Gen::nl(fhead);
+*fhead << _T("#endif");
+Gen::nl(fhead);
+*fhead << _T("extern \"C\" NLP_RUN_EXPORT bool run_analyzer(Parse *);");
 Gen::nl(fhead);																// 04/04/03 AM.
 
 // Output function head.
-*fcode << _T("bool run_analyzer(Parse *parse)");
+*fcode << _T("extern \"C\" NLP_RUN_EXPORT bool run_analyzer(Parse *parse)");
 Gen::nl(fcode);																// 04/04/03 AM.
 *fcode << _T("{");
 Gen::nl(fcode);																// 04/04/03 AM.

--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.1.21"
+#define NLP_ENGINE_VERSION "3.1.22"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
## Summary

The compile-to-DLL pipeline produced loadable but functionally-empty
`run.dll` files on Windows because `run_analyzer` was never exported.
Codegen in `lite/seqn.cpp` emitted it as `extern "C" bool run_analyzer(Parse *)`
with no `__declspec(dllexport)`, so MSVC built a DLL with zero exported
symbols. The engine's `call_runAnalyzer` (lite/dyn.cpp:111) hit
`GetProcAddress(hLibrary, "run_analyzer") == NULL`, logged
`Error in call_runAnalyzer` to `<input>_log/err.log`, and skipped all
passes — `final.tree` came out as just the `FINAL OUTPUT TREE:` header.

Linux/macOS default symbol visibility is "default" so this bug was
silent on those platforms — only Windows was affected.

## Change

- `lite/seqn.cpp`: wrap the emitted `run_analyzer` prototype + definition
  with an `NLP_RUN_EXPORT` macro that expands to `__declspec(dllexport)`
  on `_WIN32` and to nothing elsewhere.
- `nlp/main.cpp`: bump `NLP_ENGINE_VERSION` to `3.1.22`.

## Test plan

- [ ] Cut v3.1.22 release after merge
- [ ] Install v3.1.22 in the local extension dir
- [ ] In EDH, "Compile Analyzer" on date-time so a fresh tarball goes up
- [ ] Wait for cloud build to complete, .dll downloads back to analyzer dir
- [ ] Flip Run: Compiled and run date-time
- [ ] Confirm `input/text.txt_log/final.tree` matches the interpreted run
      (425 lines for date-time)