### PR TITLE
NLP-ENGINE-528 fix re-entrant analyze() use-after-free on m_nlp

### DIFF
--- a/lite/nlp_engine.cpp
+++ b/lite/nlp_engine.cpp
@@ -279,6 +279,7 @@ int NLP_ENGINE::init(
             std::_t_cerr << _T("[Couldn't make knowledge base.]") << std::endl;  // 07/21/03 AM.
             m_vtrun->rmAna(m_nlp);  // 09/27/20 AM.
             m_vtrun->deleteNLP(m_nlp);                                     // 07/21/03 AM.
+            m_nlp = 0;  // NLP-ENGINE-528: avoid dangling ptr; analyze() must not deref a deleted NLP.
     //        VTRun::deleteVTRun(m_vtrun);                                 // 07/21/03 AM.
             return -1;
         }
@@ -312,6 +313,7 @@ int NLP_ENGINE::init(
             std::_t_cerr << _T("[Couldn't build analyzer.]") << std::endl;
             m_vtrun->rmAna(m_nlp);  // 09/27/20 AM.
             m_vtrun->deleteNLP(m_nlp);                                     // 07/21/03 AM.
+            m_nlp = 0;  // NLP-ENGINE-528: avoid dangling ptr; analyze() must not deref a deleted NLP.
     //        VTRun::deleteVTRun(m_vtrun);                                 // 07/21/03 AM.
             return -1;
             }
@@ -347,11 +349,20 @@ int NLP_ENGINE::analyze(
     bool compileKB
 	)
 {
-    NLP_ENGINE::init(analyzer,develop,silent,compile,compiled,compileKB);
+    // NLP-ENGINE-528: respect init() failure. On a re-entrant analyze() in a
+    // long-lived process (e.g. the node/python addon), a name-collision in
+    // addAna can leave a fresh NLP unregistered; if make_analyzer/makeCG then
+    // fails, init() deletes m_nlp and returns -1. Charging ahead used to deref
+    // the freed m_nlp below (setIsLastFile) and SIGSEGV. Bail out cleanly.
+    if (NLP_ENGINE::init(analyzer,develop,silent,compile,compiled,compileKB) < 0)
+        return -1;
 
     // Compile mode: C++ code generation is done in init(); do not run analysis.
     if (m_compile || m_compileKB)
         return 0;
+
+    if (!m_nlp)  // defensive: never analyze without a live analyzer object.
+        return -1;
 
     readFiles(infile);
     std::string file;


### PR DESCRIPTION
## Problem
On a re-entrant `analyze()` in a long-lived process (the node/python addon), the engine deterministically SIGSEGVs on Linux:

```
[addAna: Named analyzer already present: emailaddress]
[Couldn't build analyzer.]
SIGSEGV
```

It's a use-after-free on `m_nlp` driven by a lookup-key asymmetry:

1. `NLP_ENGINE::init` looks up the existing analyzer with `m_vtrun->findAna(analyzer)` ([nlp_engine.cpp:246](lite/nlp_engine.cpp#L246)) keyed on the **path-ish `analyzer` arg** → misses on re-entry → builds a **fresh** `m_nlp`.
2. `VTRun::addAna` ([vtrun.cpp:397](lite/vtrun.cpp#L397)) dedups on **`nlp->getName()`** → hits → prints `Named analyzer already present` and returns `true` **without pushing** the new nlp.
3. `make_analyzer`/`makeCG` then fails → init runs `deleteNLP(m_nlp); return -1;` but **never nulls `m_nlp`**.
4. `analyze()` **discarded** init()'s `-1` and dereferenced the freed `m_nlp` (`setIsLastFile`) → **SIGSEGV**.

## Fix (layers 1+2 — stop the crash)
- `analyze()` now bails when `init()` returns `< 0`.
- Null `m_nlp` after `deleteNLP` in both init failure paths.
- Defensive `if (!m_nlp) return -1;` guard before the first deref in `analyze()`.

This removes the segfault and lets the addon drop its `tolerateLinuxCrash` workaround once the submodule is re-bumped.

## Not in this PR
Layer 3 — reconciling the `findAna` vs `addAna` lookup keys so re-entrant `analyze()` *reloads* the existing analyzer instead of orphaning a fresh one (i.e. re-analysis actually works, not just doesn't crash). Tracked in VisualText/nlp-engine#658.

## Testing
- [ ] Cold Linux build (`/tmp/finish-nlp-engine-528.sh`) — pending local `sudo apt install` of build deps.
- [ ] Addon repro: repeated `analyze("emailaddress", ...)` in one process no longer SIGSEGVs.

Refs: VisualText/nlp-engine#657

🤖 Generated with [Claude Code](https://claude.com/claude-code)