### PR TITLE
NLP-ENGINE-530 bump NLP_ENGINE_VERSION to 3.1.57

### DIFF
--- a/nlp/main.cpp
+++ b/nlp/main.cpp
@@ -15,7 +15,7 @@ All rights reserved.
 #include "lite/nlp_engine.h"
 #include "version.h"
 
-#define NLP_ENGINE_VERSION "3.1.56"
+#define NLP_ENGINE_VERSION "3.1.57"
 
 bool cmdReadArgs(int, _TCHAR *argv[], _TCHAR *&, _TCHAR *&, _TCHAR *&, _TCHAR *&, bool &, bool &, bool &, bool &, bool &);
 void cmdHelpargs(_TCHAR *);


### PR DESCRIPTION
The 528 re-entrant `analyze()` use-after-free fix (#3) merged to master without a version bump, leaving `NLP_ENGINE_VERSION` at `3.1.56`. Bump to `3.1.57` so released engines carry a distinct version reflecting the crash fix.

Refs: VisualText/nlp-engine#657

🤖 Generated with [Claude Code](https://claude.com/claude-code)